### PR TITLE
Fix compiler errors on Windows

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,9 +4,9 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "dev" ]
 
 jobs:
   build:

--- a/include/cameras/PerspectiveCamera.hpp
+++ b/include/cameras/PerspectiveCamera.hpp
@@ -1,6 +1,9 @@
-#define _USE_MATH_DEFINES
 #include "cameras/Camera.hpp"
 #include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #ifndef PERSPECTIVECAMERA_HPP
 #define PERSPECTIVECAMERA_HPP

--- a/include/cameras/PerspectiveCamera.hpp
+++ b/include/cameras/PerspectiveCamera.hpp
@@ -1,4 +1,4 @@
-#define __USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
 #include "cameras/Camera.hpp"
 #include <cmath>
 

--- a/include/cameras/PerspectiveCamera.hpp
+++ b/include/cameras/PerspectiveCamera.hpp
@@ -1,3 +1,4 @@
+#define __USE_MATH_DEFINES
 #include "cameras/Camera.hpp"
 #include <cmath>
 

--- a/include/materials/BlinnPhong.hpp
+++ b/include/materials/BlinnPhong.hpp
@@ -1,3 +1,4 @@
+#define __USE_MATH_DEFINES
 #include "materials/Material.hpp"
 #include <cmath>
 

--- a/include/materials/BlinnPhong.hpp
+++ b/include/materials/BlinnPhong.hpp
@@ -1,6 +1,9 @@
-#define _USE_MATH_DEFINES
 #include "materials/Material.hpp"
 #include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #ifndef BLINNPHONG_HPP
 #define BLINNPHONG_HPP

--- a/include/materials/BlinnPhong.hpp
+++ b/include/materials/BlinnPhong.hpp
@@ -1,4 +1,4 @@
-#define __USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
 #include "materials/Material.hpp"
 #include <cmath>
 

--- a/include/math/Matrix4x4.hpp
+++ b/include/math/Matrix4x4.hpp
@@ -1,4 +1,4 @@
-#define __USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
 #include "EulerRotation.hpp"
 #include "Matrix3x3.hpp"
 #include "Vector3.hpp"

--- a/include/math/Matrix4x4.hpp
+++ b/include/math/Matrix4x4.hpp
@@ -1,3 +1,4 @@
+#define __USE_MATH_DEFINES
 #include "EulerRotation.hpp"
 #include "Matrix3x3.hpp"
 #include "Vector3.hpp"

--- a/include/math/Matrix4x4.hpp
+++ b/include/math/Matrix4x4.hpp
@@ -1,10 +1,13 @@
-#define _USE_MATH_DEFINES
 #include "EulerRotation.hpp"
 #include "Matrix3x3.hpp"
 #include "Vector3.hpp"
 #include "Vector4.hpp"
 #include <array>
 #include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #ifndef MATRIX4X4_HPP
 #define MATRIX4X4_HPP

--- a/include/math/Vector3.hpp
+++ b/include/math/Vector3.hpp
@@ -1,3 +1,4 @@
+#define __USE_MATH_DEFINES
 #include "primitives/BufferAttribute.hpp"
 #include <algorithm>
 #include <cmath>

--- a/include/math/Vector3.hpp
+++ b/include/math/Vector3.hpp
@@ -1,8 +1,11 @@
-#define _USE_MATH_DEFINES
 #include "primitives/BufferAttribute.hpp"
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #ifndef VECTOR3_HPP
 #define VECTOR3_HPP

--- a/include/math/Vector3.hpp
+++ b/include/math/Vector3.hpp
@@ -1,4 +1,4 @@
-#define __USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
 #include "primitives/BufferAttribute.hpp"
 #include <algorithm>
 #include <cmath>

--- a/include/renderers/Rasterizer.hpp
+++ b/include/renderers/Rasterizer.hpp
@@ -1,4 +1,4 @@
-#define __USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
 #include "cameras/Camera.hpp"
 #include "math/Matrix3x3.hpp"
 #include "primitives/Fragment.hpp"

--- a/include/renderers/Rasterizer.hpp
+++ b/include/renderers/Rasterizer.hpp
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include "cameras/Camera.hpp"
 #include "math/Matrix3x3.hpp"
 #include "primitives/Fragment.hpp"
@@ -9,6 +8,10 @@
 #include <functional>
 #include <set>
 #include <stack>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #ifndef RASTERIZER_HPP
 #define RASTERIZER_HPP

--- a/include/renderers/Rasterizer.hpp
+++ b/include/renderers/Rasterizer.hpp
@@ -1,3 +1,4 @@
+#define __USE_MATH_DEFINES
 #include "cameras/Camera.hpp"
 #include "math/Matrix3x3.hpp"
 #include "primitives/Fragment.hpp"


### PR DESCRIPTION
The compiler errors were coming from `M_PI` not being defined. Use `ifndef` to check and define accordingly.